### PR TITLE
[Crashlytics/Android] #4 MainReceiveFragment

### DIFF
--- a/app/src/main/kotlin/com/ttvnp/ttj_asset_android_client/presentation/ui/fragment/MainReceiveFragment.kt
+++ b/app/src/main/kotlin/com/ttvnp/ttj_asset_android_client/presentation/ui/fragment/MainReceiveFragment.kt
@@ -110,6 +110,8 @@ class MainReceiveFragment : BaseMainFragment(), MainReceivePresenterTarget {
             }
         }
         bitmap = Bitmap.createScaledBitmap(bitmap, imageQRCode.width, imageQRCode.height, false)
-        imageQRCode.setImageBitmap(bitmap)
+        imageQRCode.post {
+            imageQRCode.setImageBitmap(bitmap)
+        }
     }
 }


### PR DESCRIPTION
- using the post method of the View, which will be executed only after the view measuring and layouting, this way getWidth() and getHeight() returns the actual width and height.